### PR TITLE
Fix double scrollbar & other margin / padding / line-height adjustments

### DIFF
--- a/app/javascripts/components/about.jsx
+++ b/app/javascripts/components/about.jsx
@@ -7,7 +7,7 @@ import about from "../../jsons/about.json";
 
 class About extends Component {
   render() {
-    return <div>
+    return <div className="about clearfix">
       <h3>{about[getLocale()].header}</h3>
       <p className="highlights">{about[getLocale()].description}</p>
     </div>;

--- a/app/javascripts/components/feature_speakers.jsx
+++ b/app/javascripts/components/feature_speakers.jsx
@@ -9,7 +9,7 @@ speakers["en-US"].map((speaker) => { require(`../../${speaker.image}`); });
 
 class FeatureSpeakers extends Component {
   render() {
-    return <div className="feature-speakers">
+    return <div className="feature-speakers clearfix">
       <h2>Who Spoke at g0v Summit 2014</h2>
       <div>
         {speakers[getLocale()].map((speaker) => { return <Speaker key={speaker.name} className="feature-speaker" speaker={speaker} />; })}

--- a/app/javascripts/components/footer.jsx
+++ b/app/javascripts/components/footer.jsx
@@ -13,7 +13,7 @@ class Footer extends Component {
         </ul>
       </div>
 
-      Copyright © g0v Summit 2015
+      Copyright © g0v Summit 2015・
       <a href="https://g0v.hackpad.com/ep/pad/static/2mprMIpYMz9" target="_blank">Code of Conduct</a>
     </footer>;
   }

--- a/app/javascripts/components/highlights.jsx
+++ b/app/javascripts/components/highlights.jsx
@@ -5,7 +5,7 @@ import { getLocale } from "../locale";
 
 class Hightlights extends Component {
   render() {
-    return <div>
+    return <div className="highlight clearfix">
       <h3>After g0v summit 2014</h3>
       <div className="highlights">
         <p>Here are some highlights in the local community:</p>

--- a/app/javascripts/components/mail_chimp.jsx
+++ b/app/javascripts/components/mail_chimp.jsx
@@ -18,7 +18,9 @@ class MailChimp extends Component {
     return <div id="mc_embed_signup">
       <form action="//facebook.us8.list-manage.com/subscribe/post?u=2cbe76b13b03aa196dea19786&amp;id=6acce179ae" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" className="validate" target="_blank" noValidate>
         <div id="mc_embed_signup_scroll">
-          <label htmlFor="mce-EMAIL">Subscribe to our mailing list</label>
+          <h2>
+            <label htmlFor="mce-EMAIL">Subscribe to our mailing list</label>
+          </h2>
           <input type="email" value={this.state.email} onChange={this.change.bind(this)} name="EMAIL" className="email" id="mce-EMAIL" placeholder="email address" required />
           <div style={{position: "absolute", left: "-5000px"}} aria-hidden="true"><input type="text" name="b_2cbe76b13b03aa196dea19786_6acce179ae" tabIndex="-1" value="" /></div>
           <div className="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" className="button" /></div>

--- a/app/stylesheets/application.css
+++ b/app/stylesheets/application.css
@@ -134,6 +134,9 @@ header {
       margin-left: 2.5em;
     }
   }
+  .clearfix {
+    overflow: auto;
+  }
 }
 
 .keynote, .call_for_papers, .early_bird {

--- a/app/stylesheets/application.css
+++ b/app/stylesheets/application.css
@@ -42,6 +42,7 @@ header {
   }
   h4 {
     font-size: 1.2em;
+    line-height: 1.4;
     text-align: center;
   }
   .affix {
@@ -83,18 +84,21 @@ header {
 }
 
 .cfp-button {
-  background-color: #6C5368;
-  border: none;
-  border-radius: 5px;
-  height: 34px;
-  margin: 20px auto;
-  vertical-align: middle;
-  line-height: 34px;
-  font-size: 18px;
-  cursor: pointer;
   text-align: center;
-  width: 15%;
+
   a {
+    display: inline-block;
+    background-color: #6C5368;
+    border: none;
+    border-radius: 5px;
+    height: 34px;
+    margin: 20px auto;
+    vertical-align: middle;
+    line-height: 34px;
+    font-size: 18px;
+    cursor: pointer;
+    text-align: center;
+    padding: 4px 20px;
     text-decoration: none;
   }
 }
@@ -120,6 +124,7 @@ header {
 
   h3 {
     lost-column: 1/4 2;
+    line-height: 1.4;
     margin: 0 0 1em 0;
   }
   .highlights {
@@ -137,26 +142,26 @@ header {
   }
 }
 
-.keynote, .call_for_papers, .early_bird {
+.milestones, .keynote, .call_for_papers, .early_bird, .feature-speakers, .about, .highlight{
   line-height: 1.5em;
-  margin: 0 0 4em 0;
+  margin: 0 0 84px 0;
 }
 
 .keynote-speaker {
   text-align: center;
   width: 30%;
-  margin: 0 auto;
-  margin-bottom: 1.5em;
+  margin: 1.5em auto;
   img {
     width: 120px;
     border-radius: 50%;
   }
 }
 
-.milestone, .keynote, .call_for_papers, .feature-speakers, .early_bird {
+.milestone, .keynote, .call_for_papers, .feature-speakers, .early_bird, #mc_embed_signup {
   h2 {
     font-size: 2em;
     text-align: center;
+    line-height: 1.4;
     margin: 0 0 1em 0;
   }
   h3 {
@@ -165,6 +170,12 @@ header {
   }
   .info {
     margin-top: 0.5em;
+  }
+}
+
+@media(min-width: 720px){
+  .feature-speakers h2 {
+    margin-bottom: 2em; /* enlarge horizontal gap match the vertical gaps of the circles below */
   }
 }
 
@@ -191,7 +202,6 @@ figure.feature-speaker {
 
 .milestones {
   text-align: center;
-  margin-bottom: 84px;
 }
 
 .milestone-range {
@@ -264,9 +274,7 @@ figure.feature-speaker {
 
 #mc_embed_signup_scroll {
   label {
-    text-align: center;
     font-weight: normal;
-    padding: 20px 0;
   }
 
   input.email {
@@ -285,6 +293,6 @@ figure.feature-speaker {
     border-radius: 5px;
     margin: 20px auto;
     cursor: pointer;
-    width: 15%;
+    padding: 4px 16px;
   }
 }

--- a/app/stylesheets/application.css
+++ b/app/stylesheets/application.css
@@ -105,8 +105,6 @@ header {
   background: linear-gradient(to bottom, rgba(144,110,169,0.9) 0%,rgba(193,128,170,1) 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#906ea9', endColorstr='#00c180aa',GradientType=0 );
   padding: 50px 10%;
-  height: 100%;
-  overflow : auto;
 
   @media(max-width: 720px){
     & {


### PR DESCRIPTION
- Fix double scrollbar by correctly applying clearfix on containers that contains floated descendants.
- Enlarge title line-heights so that they does not give a congested feel when titles are in multiple lines (like in narrow screens)
- Enlarge the horizontal space between sections so that section boundaries can be perceived more easily.
- Adjust button display logic so that it does not goes super narrow in narrow screens.

![screencapture-localhost-8080-2016-1455905220131](https://cloud.githubusercontent.com/assets/108608/13184447/f3c6eeee-d776-11e5-8d46-54a30dac4b91.png)
