### PR TITLE
Use flexbox to vertical center align sponsors

### DIFF
--- a/app/javascripts/components/Sponsors/styles.css
+++ b/app/javascripts/components/Sponsors/styles.css
@@ -26,6 +26,8 @@
 }
 
 .list {
+  display: flex;
+  justify-content: center;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -33,6 +35,8 @@
 
 .item {
   display: inline-block;
+  display: flex;
+  align-items: center;
   font-size: 16px;
   width: 180px;
   height: 119px;


### PR DESCRIPTION
Use [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) to vertical align sponsors(共同主辦). Browser's don't support this feature will not have any difference from current reversion. Use a progressive enhancement way to do this.

After apply this patch:

![2016-03-03 3 18 21](https://cloud.githubusercontent.com/assets/16474/13488190/a6bdf7ee-e15a-11e5-9bbb-67bc3f4ede2c.png)
