### PR TITLE
Fix appbar incorrect layout in old IE

### DIFF
--- a/app/javascripts/components/AppBar/styles.css
+++ b/app/javascripts/components/AppBar/styles.css
@@ -22,6 +22,7 @@
 }
 
 .title {
+  float: left;
   font-family: Audiowide;
   margin: 0;
   text-transform: uppercase;
@@ -29,11 +30,13 @@
 }
 
 .live {
+  float: left;
   display: inline-block;
   padding-top: 13px;
 }
 
 .menu {
+  float: left;
   margin: 0;
   padding: 0;
   list-style: none;


### PR DESCRIPTION
Appbar uses `display: flex;` so old IE won't display well. This patch fix this issue by treat the appbar as normal block division. And use `float` to place content.

Tested on IE9, latest Firefox, Chrome

Before:

![2016-03-03 4 26 44](https://cloud.githubusercontent.com/assets/16474/13488645/826cf374-e15d-11e5-9f7f-5791c5d33dfb.png)

After:

![2016-03-03 4 27 16](https://cloud.githubusercontent.com/assets/16474/13488671/a9df79fe-e15d-11e5-8b02-cde05523eb70.png)
