### PR TITLE
Patch/appbar valign

### DIFF
--- a/app/javascripts/components/AppBar/index.jsx
+++ b/app/javascripts/components/AppBar/index.jsx
@@ -104,27 +104,33 @@ class Header extends Component {
 const Menu = () => {
   return (
     <ul className={styles.menu}>
-      <IndexLink
-        activeClassName={styles.active}
+      <li 
         className={styles.item}
-        to="/"
-      >
-        {info[getLocale()].home}
-      </IndexLink>
-      <Link
-        activeClassName={styles.active}
+        activeClassName={styles.active}>
+        <IndexLink
+          to="/"
+        >
+          {info[getLocale()].home}
+        </IndexLink>
+      </li>
+      <li 
         className={styles.item}
-        to="schedules"
-      >
-        {info[getLocale()].schedule}
-      </Link>
-      <Link
-        activeClassName={styles.active}
+        activeClassName={styles.active}>
+        <Link
+          to="schedules"
+        >
+          {info[getLocale()].schedule}
+        </Link>
+      </li>
+      <li 
         className={styles.item}
-        to="speakers"
-      >
-        {info[getLocale()].speakers}
-      </Link>
+        activeClassName={styles.active}>
+        <Link
+          to="speakers"
+        >
+          {info[getLocale()].speakers}
+        </Link>
+      </li>
       <li className={styles.item}>
         {info[getLocale()].sponsors}
       </li>

--- a/app/javascripts/components/AppBar/styles.css
+++ b/app/javascripts/components/AppBar/styles.css
@@ -47,7 +47,8 @@
 .item {
   display: inline-block;
   height: 100%;
-  padding: 14px 26px 18px 26px;
+  padding: 21px 26px 21px 26px;
+  line-height: 1;
   text-align: center;
   cursor: pointer;
   text-decoration: none;
@@ -86,8 +87,9 @@
 .button {
   display: inline-block;
   color: #FFF;
-  padding: 14px 10px 0 0;
+  padding: 21px 10px 0 0;
   height: 100%;
+  line-height: 1;
   width: 94px;
   text-decoration: none;
   text-align: right;

--- a/app/javascripts/components/AppBar/styles.css
+++ b/app/javascripts/components/AppBar/styles.css
@@ -76,6 +76,9 @@
   color: #000;
   box-shadow: 0px -1px 2px 0px rgba(0,0,0,0.50);
 }
+.item:hover a {
+  color: #000;
+}
 
 .lang {
   position: absolute;


### PR DESCRIPTION
Two commit in this PR.
The main purpose is to fix the baseline alignment of appbar

Before:
<img width="1387" alt="2016-03-05 10 56 25" src="https://cloud.githubusercontent.com/assets/16474/13545304/4cc2cb48-e2c2-11e5-993b-06000ca627c7.png">

Now:
<img width="1386" alt="2016-03-05 10 56 52" src="https://cloud.githubusercontent.com/assets/16474/13545305/51bdc51c-e2c2-11e5-9fed-1ec3dfd627d6.png">

The second commit is to fix the incorrect markup structure in appbar.
Old markup have `<a>` direct in `<ul>`.
Now wrap them in a `<li>`
