### PR TITLE
Fix appbar click region

### DIFF
--- a/app/javascripts/components/AppBar/index.jsx
+++ b/app/javascripts/components/AppBar/index.jsx
@@ -104,32 +104,42 @@ class Header extends Component {
 const Menu = () => {
   return (
     <ul className={styles.menu}>
-      <IndexLink
-        activeClassName={styles.active}
+      <li 
         className={styles.item}
-        to="/"
-      >
-        {info[getLocale()].home}
-      </IndexLink>
-      <Link
-        activeClassName={styles.active}
+        activeClassName={styles.active}>
+        <IndexLink
+          to="/"
+        >
+          {info[getLocale()].home}
+        </IndexLink>
+      </li>
+      <li 
         className={styles.item}
-        to="schedules"
-      >
-        {info[getLocale()].schedule}
-      </Link>
-      <Link
-        activeClassName={styles.active}
+        activeClassName={styles.active}>
+        <Link
+          to="schedules"
+        >
+          {info[getLocale()].schedule}
+        </Link>
+      </li>
+      <li 
         className={styles.item}
-        to="speakers"
-      >
-        {info[getLocale()].speakers}
-      </Link>
-      <li className={styles.item}>
-        {info[getLocale()].sponsors}
+        activeClassName={styles.active}>
+        <Link
+          to="speakers"
+        >
+          {info[getLocale()].speakers}
+        </Link>
       </li>
       <li className={styles.item}>
-        {info[getLocale()].transport}
+        <span>
+          {info[getLocale()].sponsors}
+        </span>
+      </li>
+      <li className={styles.item}>
+        <span>
+          {info[getLocale()].transport}
+        </span>
       </li>
     </ul>
   );

--- a/app/javascripts/components/AppBar/styles.css
+++ b/app/javascripts/components/AppBar/styles.css
@@ -47,6 +47,11 @@
 .item {
   display: inline-block;
   height: 100%;
+} 
+.item a, 
+.item span {
+  display: block;
+  height: 100%;
   padding: 21px 26px 21px 26px;
   line-height: 1;
   text-align: center;
@@ -75,6 +80,10 @@
   background-color: #FFF;
   color: #000;
   box-shadow: 0px -1px 2px 0px rgba(0,0,0,0.50);
+}
+.item:hover a,
+.item:hover span {
+  color: #000;
 }
 
 .lang {


### PR DESCRIPTION
Expand the clickable region of appbar item to the entire white block.

Issue produced by my old PR #98
