### PR TITLE
Show schedule day when user link to day anchor

### DIFF
--- a/app/javascripts/components/Schedule/styles.css
+++ b/app/javascripts/components/Schedule/styles.css
@@ -11,11 +11,19 @@
   padding-left: 29px;
   padding-right: 29px;
 }
+.section h3 {
+  margin-top: -70px;
+  padding-top: 70px;
+}
+.section h3 a:visited {
+  color: #000;
+}
 
 .table {
   max-width: 100%;
   overflow: auto;
   display: block;
+  margin-bottom: 40px;
 }
 .table th:nth-of-type(n+2) {
   width: 30%;


### PR DESCRIPTION
Current schedule day anchor will not able to see which day.
The day number is been over covered by the appbar at first screen.

Add negative margin top and positive padding top to fix this issue.

Also changes:
- Space between day1 and day2
- Day link color force to black, instead of browser's default
