### PR TITLE
Use *.html as link url

### DIFF
--- a/app/javascripts/components/AppBar/index.jsx
+++ b/app/javascripts/components/AppBar/index.jsx
@@ -117,7 +117,7 @@ const Menu = () => {
         className={styles.item}
         activeClassName={styles.active}>
         <Link
-          to="/2016/schedules"
+          to="/2016/schedules.html"
         >
           {info[getLocale()].schedule}
         </Link>
@@ -126,7 +126,7 @@ const Menu = () => {
         className={styles.item}
         activeClassName={styles.active}>
         <Link
-          to="/2016/speakers"
+          to="/2016/speakers.html"
         >
           {info[getLocale()].speakers}
         </Link>

--- a/app/javascripts/routes.js
+++ b/app/javascripts/routes.js
@@ -8,8 +8,8 @@ export default () => {
     <Route path="/2016" component={Root}>
        { /* Home (main) route */ }
        <IndexRoute component={Home}/>
-       <Route path="speakers" component={Speakers} />
-       <Route path="schedules*" component={Schedules} />
+       <Route path="speakers.html" component={Speakers} />
+       <Route path="schedules.html" component={Schedules} />
        {/*<Route path="sponsors" component={Sponsors} />*/}
        {/*<Route path="*" component={NotFound} status={404} />*/}
      </Route>

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -4,13 +4,13 @@ import webpack from 'webpack'
 import {resolve} from 'path'
 import {server as superstatic} from 'superstatic'
 
-const paths = ['index', 'schedules', 'speakers']
+const paths = ['index.html', 'schedules.html', 'speakers.html']
 const PORT = 8081;
 const server = superstatic({
   port: PORT,
   cwd: resolve(__dirname, '../dist'),
   config: {
-    cleanUrls: true,
+    cleanUrls: false,
     debug: true,
     rewrites: paths.map(path => ({source: `/2016/${path}`, destination: '/2016/index.html'}))
   }
@@ -22,7 +22,7 @@ let connectApp = server.listen(async () => {
   console.log(`Static server listening at http://localhost:${PORT}`)
 
   await Promise.all(paths.map(async (path) => {
-    const filePath = resolve(__dirname, `../dist/2016/${path}.html`)
+    const filePath = resolve(__dirname, `../dist/2016/${path}`)
     const html = await renderToString(path)
 
     await writeFileAsync(filePath, html, 'utf-8')


### PR DESCRIPTION
Use `*.html` in appbar's link.
Also build tool will garb and generate `*.html`

With real html in path, github pages can really serve them.
Then search engine can grab the content of these pages
