### PR TITLE
Schedule lightbox max height

### DIFF
--- a/app/javascripts/components/Schedule/styles.css
+++ b/app/javascripts/components/Schedule/styles.css
@@ -63,13 +63,13 @@
   display: inline-block;
   vertical-align: middle;
   height: auto;
-  max-height: 100vh;
-  overflow: scroll;
+  max-height: 90%;
   width: 70%;
   background-color: #fff;
   text-align: justify;
   padding: 20px;
   word-wrap: break-word;
+  overflow-y: auto;
 }
 
 .lightboxheading {


### PR DESCRIPTION
Replace the old style

``` css
overflow: scroll;
max-height: 100vh;
```

To

``` css
overflow-y: auto;
max-height: 90%;
```

Reasons:
- `overflow` is for better looking in normal browsers(browsers without native auto hidden scrollbar).
- `max-height` is for to match the same present style at horizontal direction(width). 
