### PR TITLE
Fix appbar active item style

### DIFF
--- a/app/javascripts/components/AppBar/index.jsx
+++ b/app/javascripts/components/AppBar/index.jsx
@@ -109,6 +109,7 @@ const Menu = () => {
         activeClassName={styles.active}>
         <IndexLink
           to="/2016"
+          activeClassName={styles.active}
         >
           {info[getLocale()].home}
         </IndexLink>
@@ -118,6 +119,7 @@ const Menu = () => {
         activeClassName={styles.active}>
         <Link
           to="/2016/schedules.html"
+          activeClassName={styles.active}
         >
           {info[getLocale()].schedule}
         </Link>

--- a/app/javascripts/components/AppBar/styles.css
+++ b/app/javascripts/components/AppBar/styles.css
@@ -65,15 +65,10 @@
   color: #FFF;
 }
 
-.active {
-  composes: item;
+.item a.active {
   background-color: #FFF;
   color: #000;
-}
-
-.active a {
   text-decoration: none;
-  color: #000;
 }
 
 .item:hover {


### PR DESCRIPTION
Auto active function from React Router only functional on `<Link>` element.
So add back `activeClass` back to `<Link>` and modify style to fit this structure.
