### PR TITLE
Remove .html in path so that historyApiFallback works

### DIFF
--- a/app/javascripts/components/AppBar/index.jsx
+++ b/app/javascripts/components/AppBar/index.jsx
@@ -117,7 +117,7 @@ const Menu = () => {
         className={styles.item}
         activeClassName={styles.active}>
         <Link
-          to="/2016/schedules.html"
+          to="/2016/schedules"
         >
           {info[getLocale()].schedule}
         </Link>
@@ -126,7 +126,7 @@ const Menu = () => {
         className={styles.item}
         activeClassName={styles.active}>
         <Link
-          to="/2016/speakers.html"
+          to="/2016/speakers"
         >
           {info[getLocale()].speakers}
         </Link>

--- a/app/javascripts/routes.js
+++ b/app/javascripts/routes.js
@@ -8,8 +8,8 @@ export default () => {
     <Route path="/2016" component={Root}>
        { /* Home (main) route */ }
        <IndexRoute component={Home}/>
-       <Route path="speakers.html" component={Speakers} />
-       <Route path="schedules.html" component={Schedules} />
+       <Route path="speakers" component={Speakers} />
+       <Route path="schedules" component={Schedules} />
        {/*<Route path="sponsors" component={Sponsors} />*/}
        {/*<Route path="*" component={NotFound} status={404} />*/}
      </Route>

--- a/app/javascripts/routes.js
+++ b/app/javascripts/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IndexRoute, Route } from 'react-router';
+import { IndexRoute, Route, Redirect } from 'react-router';
 import { Root } from 'javascripts/components';
 import { Home, Speakers, Schedules } from 'javascripts/pages';
 
@@ -8,6 +8,7 @@ export default () => {
     <Route path="/2016" component={Root}>
        { /* Home (main) route */ }
        <IndexRoute component={Home}/>
+       <Redirect from=":page.html" to=":page" /> {/* Only works after prerendering */}
        <Route path="speakers" component={Speakers} />
        <Route path="schedules" component={Schedules} />
        {/*<Route path="sponsors" component={Sponsors} />*/}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postbuild": "babel-node scripts/prerender",
     "test": "npm run build",
     "webpack": "webpack --watch -d --display-reasons --display-chucks --progress",
-    "start": "webpack-dev-server --config webpack.config.babel.js --hot --inline",
+    "start": "rm -rf dist; webpack-dev-server --config webpack.config.babel.js --hot --inline",
     "start:dist": "superstatic dist"
   },
   "repository": {

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -5,13 +5,13 @@ import webpack from 'webpack'
 import {resolve} from 'path'
 import {server as superstatic} from 'superstatic'
 
-const paths = ['index.html', 'schedules.html', 'speakers.html']
+const paths = ['index', 'schedules', 'speakers']
 const PORT = 8081;
 const server = superstatic({
   port: PORT,
   cwd: resolve(__dirname, '../dist'),
   config: {
-    cleanUrls: false,
+    cleanUrls: true,
     debug: true,
     rewrites: paths.map(path => ({source: `/2016/${path}`, destination: '/2016/index.html'}))
   }
@@ -23,12 +23,12 @@ let connectApp = server.listen(async () => {
   console.log(`Static server listening at http://localhost:${PORT}`)
 
   await Promise.all(paths.map(async (path) => {
-    const filePath = resolve(__dirname, `../dist/2016/${path}`)
+    const outputFilePath = resolve(__dirname, `../dist/2016/${path}.html`)
     const html = await renderToString(path)
 
-    await writeFileAsync(filePath, html, 'utf-8')
+    await writeFileAsync(outputFilePath, html, 'utf-8')
 
-    console.log('Rendered ', path, 'to', filePath)
+    console.log('Rendered ', path, 'to', outputFilePath)
   }))
 
   console.log('All rendered, closing down the server...')


### PR DESCRIPTION
1. Removes `.html` in URLs: webpack historyApiFallback does not rewrite URLs [if the path contains `.`](https://github.com/bripkens/connect-history-api-fallback/blob/master/lib/index.js#L59). On the other hand, removing `.html` does not effect SEO (because Github Pages serves html files even without .html suffix), thus this pull request removes .html in the path.
2. Removes `dist` directory when runnning `npm start`: with prerendered pages stored inside `dist`, webpack-dev-server would serve prerendered assets instead of the fresh one in memory, and HMR would not start as well. For the sake of easy development, it is better if we remove dist/ before starting webpack-dev-server.
3. Redirect `/2016/xxx.html` paths to `/2016/xxx` so that visitors with old URLs would not get lost.
