### PR TITLE
Fix #130, different json-ld for different page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,7 +7,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link href='https://fonts.googleapis.com/css?family=Audiowide:400' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600' rel='stylesheet' type='text/css' />
-    <script type="application/ld+json"><%= htmlWebpackPlugin.options.jld %></script>
+    <script id="jld" type="application/ld+json"><%= htmlWebpackPlugin.options.jld %></script>
     <meta property="og:image" content="http://summit.g0v.tw<%= require('file!../images/og.png') %>">
     <meta property="og:description" content="<%= htmlWebpackPlugin.options.description %>">
     <meta name="twitter:card" content="summary_large_image">

--- a/jld.js
+++ b/jld.js
@@ -7,7 +7,8 @@ const ROOM = {
     "@type": "Place",
     "@id": "#Rall",
     "name": "所有會議廳 All Conference Room",
-    "address": "台北市南港區研究院路二段128號3F / 3F No.128, Sec. 2, Academia Rd., Nangang Dist., Taipei City 115, Taiwan"
+    "address": "台北市南港區研究院路二段128號3F / 3F No.128, Sec. 2, Academia Rd., Nangang Dist., Taipei City 115, Taiwan",
+    "url": "http://hssb.committee.sinica.edu.tw/"
   },
   "R0": {
     "@type": "Place",
@@ -32,105 +33,112 @@ const ROOM = {
   }
 };
 
-var base = {
-  "@context": "http://schema.org",
-  "@type": "Event",
-  "name": "g0v Summit 2016 Conference",
-  "url": "http://summit.g0v.tw/2016/",
-  "startDate": "2016-05-14T09:00:00.000+08:00",
-  "endDate": "2016-05-15T17:40:00.000+08:00",
-  "location": {
-    "@type": "EventVenue",
-    "name": "中研院人文社會科學館 / Social Sciences Building, Academia Sinica, Taipei, Taiwan",
-    "address": "台北市南港區研究院路二段128號 / No.128, Sec. 2, Academia Rd., Nangang Dist., Taipei City 115, Taiwan"
+const offers = [
+  {
+    "@type": "Offer",
+    "@id": "#offer-earlybird",
+    "name": "Apply for International Early Bird's ticket",
+    "category": "primary",
+    "price": 0.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/early-bird",
+    "validFrom": "2016-02-15T20:00:00.000+08:00",
+    "validThrough": "2016-03-20T23:59:00.000+08:00"
   },
-  "subEvents": [],
-  "offers": [
-    {
-      "@type": "Offer",
-      "@id": "#offer-earlybird",
-      "name": "Apply for International Early Bird's ticket",
-      "category": "primary",
-      "price": 0.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/early-bird",
-      "validFrom": "2016-02-15T20:00:00.000+08:00",
-      "validThrough": "2016-03-20T23:59:00.000+08:00"
-    },
-    {
-      "@type": "Offer",
-      "@id": "#offer-regular",
-      "name": "Attendee (一般票)",
-      "category": "primary",
-      "price": 1200.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/conference",
-      "validFrom": "2016-04-01T20:00:00.000+08:00",
-      "validThrough": "2016-04-15T23:59:00.000+08:00"
-    },
-    {
-      "@type": "Offer",
-      "@id": "#offer-regular-donate",
-      "name": "Attendee (一般票) + NT$500 donate OCF",
-      "category": "primary",
-      "price": 1700.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/conference",
-      "validFrom": "2016-04-01T20:00:00.000+08:00",
-      "validThrough": "2016-04-15T23:59:00.000+08:00"
-    },
-    {
-      "@type": "Offer",
-      "@id": "#offer-regular-invite",
-      "name": "Attendee with invite code (一般邀請票)",
-      "category": "premium",
-      "price": 1200.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/conference",
-      "validFrom": "2016-04-01T20:00:00.000+08:00",
-      "validThrough": "2016-04-15T23:59:00.000+08:00"
-    },
-    {
-      "@type": "Offer",
-      "@id": "#offer-vip",
-      "name": "Attendee with VIP invite code (VIP 票)",
-      "category": "premium",
-      "price": 800.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/conference",
-      "validFrom": "2016-02-29T20:00:00.000+08:00",
-      "validThrough": "2016-03-30T23:59:00.000+08:00"
-    },
-    {
-      "@type": "Offer",
-      "@id": "#offer-vip-donate",
-      "name": "Attendee with VIP invite code (VIP 票) + NT$500 donate OCF",
-      "category": "premium",
-      "price": 1300.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/conference",
-      "validFrom": "2016-02-29T20:00:00.000+08:00",
-      "validThrough": "2016-03-30T23:59:00.000+08:00"
-    },
-    {
-      "@type": "Offer",
-      "@id": "#offer-reserved",
-      "name": "Attendee with reserved invite code (保留票)",
-      "category": "premium",
-      "price": 0.0,
-      "priceCurrency": "TWD",
-      "availability": "InStock",
-      "url": "http://g0v-summit2016.kktix.cc/events/conference",
-      "validFrom": "2016-02-15T20:00:00.000+08:00",
-      "validThrough": "2016-05-13T23:59:00.000+08:00"
+  {
+    "@type": "Offer",
+    "@id": "#offer-regular",
+    "name": "Attendee (一般票)",
+    "category": "primary",
+    "price": 1200.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/conference",
+    "validFrom": "2016-04-01T20:00:00.000+08:00",
+    "validThrough": "2016-04-15T23:59:00.000+08:00"
+  },
+  {
+    "@type": "Offer",
+    "@id": "#offer-regular-donate",
+    "name": "Attendee (一般票) + NT$500 donate OCF",
+    "category": "primary",
+    "price": 1700.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/conference",
+    "validFrom": "2016-04-01T20:00:00.000+08:00",
+    "validThrough": "2016-04-15T23:59:00.000+08:00"
+  },
+  {
+    "@type": "Offer",
+    "@id": "#offer-regular-invite",
+    "name": "Attendee with invite code (一般邀請票)",
+    "category": "premium",
+    "price": 1200.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/conference",
+    "validFrom": "2016-04-01T20:00:00.000+08:00",
+    "validThrough": "2016-04-15T23:59:00.000+08:00"
+  },
+  {
+    "@type": "Offer",
+    "@id": "#offer-vip",
+    "name": "Attendee with VIP invite code (VIP 票)",
+    "category": "premium",
+    "price": 800.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/conference",
+    "validFrom": "2016-02-29T20:00:00.000+08:00",
+    "validThrough": "2016-03-30T23:59:00.000+08:00"
+  },
+  {
+    "@type": "Offer",
+    "@id": "#offer-vip-donate",
+    "name": "Attendee with VIP invite code (VIP 票) + NT$500 donate OCF",
+    "category": "premium",
+    "price": 1300.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/conference",
+    "validFrom": "2016-02-29T20:00:00.000+08:00",
+    "validThrough": "2016-03-30T23:59:00.000+08:00"
+  },
+  {
+    "@type": "Offer",
+    "@id": "#offer-reserved",
+    "name": "Attendee with reserved invite code (保留票)",
+    "category": "premium",
+    "price": 0.0,
+    "priceCurrency": "TWD",
+    "availability": "InStock",
+    "url": "http://g0v-summit2016.kktix.cc/events/conference",
+    "validFrom": "2016-02-15T20:00:00.000+08:00",
+    "validThrough": "2016-05-13T23:59:00.000+08:00"
+  }
+];
+
+var Base = function () {
+  var base = {
+    "@context": "http://schema.org",
+    "@type": "Event",
+    "@id": "g0v-summit-2016",
+    "name": "g0v Summit 2016 Conference",
+    "url": "http://summit.g0v.tw/2016/",
+    "startDate": "2016-05-14T09:00:00.000+08:00",
+    "endDate": "2016-05-15T17:40:00.000+08:00",
+    "location": {
+      "@type": "EventVenue",
+      "name": "中研院人文社會科學館 / Social Sciences Building, Academia Sinica, Taipei, Taiwan",
+      "address": "台北市南港區研究院路二段128號 / No.128, Sec. 2, Academia Rd., Nangang Dist., Taipei City 115, Taiwan",
+      "url": "http://hssb.committee.sinica.edu.tw/"
     }
-  ]
+  };
+  var about_data = jsonfile.readFileSync('./app/jsons/about.json');
+  base.description = `${about_data["zh-TW"].description} / ${about_data["en-US"].description}`;
+  return base;
 };
 
 var talk = function (name, description, performers, start, end, location) {
@@ -139,7 +147,7 @@ var talk = function (name, description, performers, start, end, location) {
     location: location,
     "startDate": start,
     "endDate": end,
-    "offers": offers
+    "offers": offers_ref
   };
 
   if (name) {
@@ -192,50 +200,93 @@ var html2text = function (html) {
   return htmlToText.fromString(html, {wordwrap: null}).replace(/\n/g, ' ');
 };
 
-var offers = base.offers.map(function (offer) {
+var offers_ref = offers.map(function (offer) {
   return {
     "@id": offer["@id"]
   };
 });
 
-var about_data = jsonfile.readFileSync('app/jsons/about.json');
-base.description = `${about_data["zh-TW"].description} / ${about_data["en-US"].description}`;
+var basic = JSON.stringify(function () {
+  var base = Base();
+  base.offers = offers;
 
-var schedule_data = jsonfile.readFileSync('app/javascripts/components/Schedule/schedules.json');
+  return base;
+}());
 
-var day1 = schedule_data["en-US"]["day1"];
-var day2 = schedule_data["en-US"]["day2"];
 
-var slot, event;
-var day, start, end, temp;
+var schedule = JSON.stringify(function () {
+  var base = Base();
+  base.subEvents = [];
 
-var performers;
+  var schedule_data = jsonfile.readFileSync('./app/javascripts/components/Schedule/schedules.json');
 
-var days = [[], day1, day2];
+  var day1 = schedule_data["en-US"]["day1"];
+  var day2 = schedule_data["en-US"]["day2"];
 
-for (day in days) {
-  for (slot of days[day]) {
-    if (!slot.events) {
-      slot.events = [slot.event];
-    }
-    temp = slot.time.split('-');
-    start = temp[0];
-    end = temp[1];
+  var slot, event;
+  var day, start, end, temp;
 
-    for (event of slot.events) {
-      performers = null;
-      if (event.title && event.title !== 'TBA') {
-        if (event.speaker) {
-          performers = event.speaker.split(/[,&]/).map(function (name) {
-            return person(name.trim());
-          });
+  var performers;
+
+  var days = [[], day1, day2];
+
+  for (day in days) {
+    for (slot of days[day]) {
+      if (!slot.events) {
+        slot.events = [slot.event];
+      }
+      temp = slot.time.split('-');
+      start = temp[0];
+      end = temp[1];
+
+      for (event of slot.events) {
+        performers = null;
+        if (event.title && event.title !== 'TBA') {
+          if (event.speaker) {
+            performers = event.speaker.split(/[,&]/).map(function (name) {
+              return person(name.trim());
+            });
+          }
+
+          base.subEvents.push(talk(event.title, html2text(event.abstract), performers, datetime(day, start), datetime(day, end), location_by_room(event.venue)));
         }
-
-        base.subEvents.push(talk(event.title, html2text(event.abstract), performers, datetime(day, start), datetime(day, end), location_by_room(event.venue)));
       }
     }
   }
-}
+
+  return base;
+}());
+
+var sponsors = JSON.stringify(function () {
+  var base = [Base()];
+  var sponsors_data = jsonfile.readFileSync('./app/jsons/sponsors.json')['en-US'];
+
+  for (let cat of sponsors_data) {
+    for (let sponsor of cat.sponsors) {
+      var agent = {
+        "@type": "Organization",
+        "name": sponsor.name
+      };
+
+      if (sponsor.url) {
+        agent.url = sponsor.url;
+      }
+      if (sponsor.desc) {
+        agent.description = sponsor.desc;
+      }
+      base.push({
+        "@context": "http://schema.org",
+        "@type": "JoinAction",
+        "agent": agent,
+        "object": {
+          "@id": "g0v-summit-2016",
+        }
+      });
+    }
+  }
+
+  return base;
+}());
 
 
-export default JSON.stringify(base);
+export {basic, schedule, sponsors}

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -4,6 +4,8 @@ import Browser from 'zombie'
 import {resolve} from 'path'
 import {server as superstatic} from 'superstatic'
 
+import {basic, schedule, sponsors} from '../jld.js'
+
 /*
 * Page data to prerender.
 *
@@ -19,15 +21,19 @@ import {server as superstatic} from 'superstatic'
 */
 const PAGES = [{
   path: 'index',
+  ld: basic
 }, {
   path: 'schedules',
   title: '議程表',
+  ld: schedule
 }, {
   path: 'speakers',
   title: '講者',
+  ld: basic
 }, {
   path: 'sponsors',
   title: '贊助商',
+  ld: sponsors
 }]
 
 
@@ -73,6 +79,10 @@ async function renderToString(page){
   if(page.title) {
     let titleElem = browser.document.querySelector('title')
     titleElem.innerHTML = `${page.title} :: ${titleElem.innerHTML}`
+  }
+  if(page.ld) {
+    let jld = browser.document.querySelector('#jld')
+    jld.innerHTML = page.ld
   }
 
   if(page.ogImage) {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -4,7 +4,7 @@ import HtmlWebpackPlugin from "html-webpack-plugin";
 import ExtractTextPlugin from "extract-text-webpack-plugin";
 import autoprefixer from "autoprefixer";
 
-import jld from "./jld.js";
+import {basic} from "./jld.js";
 
 export default {
 
@@ -70,7 +70,7 @@ export default {
     new ExtractTextPlugin("[name].[hash].css"),
     new HtmlWebpackPlugin({
       title: "啥米零時政府 g0v 2016 summit",
-      jld: jld,
+      jld: basic,
       description: "2014 之後又跳過了一整年，g0v summit 2016 再次邀請全球公民技術社群來分享公務員，技術人員，和非政府組織工作人員之間的協作經驗。我們很高興邀請到 Filipe Heusser 擔任今年的專題演講者，他也是 the Chilean NGO Ciudadano Inteligente 的創辦人和前股東，以及 Berkman Center 的成員。",
       filename: "index.html",
       template: "app/templates/index.html"


### PR DESCRIPTION
Current implement supports index, schedule and sponsors page.

`index` only contains basic and offers information.
`schedule` is the previous full json-ld (with sub events).
`sponsors` is new, provide linking between g0v summit event and all sponsors(org). Use [JoinAction](https://schema.org/JoinAction)

Feature todo, move jld.js to `scripts/` and speakers page(waiting for data update).
