### PR TITLE
Separate parallel sessions from following-up keynote sessions

### DIFF
--- a/app/javascripts/components/Schedule/filter.jsx
+++ b/app/javascripts/components/Schedule/filter.jsx
@@ -1,20 +1,26 @@
-import React from "react";
+import React, {PropTypes} from "react";
 import styles from "./filter.css";
 
 export default React.createClass({
   displayName: "Filter",
 
+  propTypes: {
+    title: PropTypes.string.isRequired,
+    data: PropTypes.arrayOf(PropTypes.shape({
+      active: PropTypes.bool,
+      color: PropTypes.string,
+      title: PropTypes.string,
+    })).isRequired,
+    filterOn: PropTypes.bool,
+    toggleCategoryHandler: PropTypes.func.isRequired,
+    clearCategoryHandler: PropTypes.func.isRequired,
+    togglePanelHandler: PropTypes.func,
+  },
+
   render() {
 
-    // var array = Array.apply(null, {length: 10}).map(Number.call, Number)
-    // var fakeItems = array.map((value,i)=>{
-    //   return (
-    //     <li className="Filter-category" key={i}>CATEGORY</li>
-    //   )
-    // });
-
-    var {data, filterOn, toggleCategoryHandler, clearCategoryHandler, togglePanelHander} = this.props;
-    var items = data.map((value,i)=>{
+    var {filterOn} = this.props;
+    var items = this.props.data.map((value,i)=>{
 
       if(!filterOn || value.active){
         var style = {
@@ -27,7 +33,7 @@ export default React.createClass({
       }
 
       return (
-        <div className={styles.filterCategory} key={i} onClick={toggleCategoryHandler.bind(null,i)}>
+        <div className={styles.filterCategory} key={i} onClick={this.props.toggleCategoryHandler.bind(null,i)}>
           <div className={`${styles.filterCategoryIcon}`} style={style}></div>
           <div className={`${styles.filterCategoryText}`}>{value.title}</div>
         </div>
@@ -36,11 +42,11 @@ export default React.createClass({
 
     return (
       <div className={styles.filter}>
-        <div className={styles.filterTitle}>Venues</div>
+        <div className={styles.filterTitle}>{this.props.title}</div>
           <div className={styles.filterCategories}>{items}</div>
           <div className={styles.filterActions}>
-            <div className={styles.filterClose} onClick={togglePanelHander}>Close</div>
-            <div className={`${styles.filterClearAll} ${filterOn ? styles.isActive : ''}`} onClick={clearCategoryHandler}>All Topics</div>
+            <div className={styles.filterClose} onClick={this.props.togglePanelHandler}>Close</div>
+            <div className={`${styles.filterClearAll} ${filterOn ? styles.isActive : ''}`} onClick={this.props.clearCategoryHandler}>All {this.props.title.toLowerCase()}</div>
           </div>
       </div>
     );

--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -15,9 +15,9 @@ function mapTimeSlotToItems(day, value, i) {
   let { hash } = this.props.location;
   let selected = hash ? (hash === '#' + id) : false;
   let event = () => schedules[getLocale()][`day${day}`][i].event;
-  if(venue && this.state.categoryOn) {
-    let category = this.state.categories.filter(cat => cat.title === venue)[0]
-    if(!category.active) return false;
+  if(venue && this.state.venueOn) {
+    let venueState = this.state.venues.filter(cat => cat.title === venue)[0]
+    if(!venueState.active) return false;
   }
 
   let content;
@@ -72,7 +72,7 @@ function mapTimeSlotToItems(day, value, i) {
   }
 }
 
-const categories = [
+const venues = [
   {
     "id": "r0",
     "title": "R0",
@@ -95,15 +95,15 @@ export default class Schedule extends Component {
     super(props);
     this.state = {
     showSession: false,
-    categoryOn: false,
+    venueOn: false,
     mobileFilterOn: false,
-    categories: categories.map(category => ({...category, active: false})),
+    venues: venues.map(venue => ({...venue, active: false})),
     currentSection: '',
     currentSession: () => ({}),
     currentSessionTime: null,
     };
   }
- 
+
   componentDidMount() {
     const { hash } = this.props.location;
     if (hash) {
@@ -139,15 +139,15 @@ export default class Schedule extends Component {
     console.log(currentSection)
     this.setState({ currentSection });
   }
-  toggleCategory = id => {
-    let categories = this.state.categories.slice(0);
-    categories[id] = {...categories[id], active: !categories[id].active}
-    this.setState({categories, categoryOn: true})
+  toggleVenue = id => {
+    let venues = this.state.venues.slice(0);
+    venues[id] = {...venues[id], active: !venues[id].active}
+    this.setState({venues, venueOn: true})
   }
-  clearCategory = () => {
+  clearVenue = () => {
     this.setState({
-      categories: categories.map(category => ({...category, active: false})),
-      categoryOn: false
+      venues: venues.map(venue => ({...venue, active: false})),
+      venueOn: false
     })
   }
   toggleMobileFilter = () => {
@@ -156,18 +156,17 @@ export default class Schedule extends Component {
   render () {
     return (
       <div className={styles.root}>
-        <div style={{ color: '#FFF', backgroundColor: '#000', padding: '20px', textAlign: 'center'}}>{schedules[getLocale()].interpretation}
-        </div>
+        <div style={{ color: '#FFF', backgroundColor: '#000', padding: '20px', textAlign: 'center'}}>{schedules[getLocale()].interpretation}</div>
         <div className={styles.container}>
           <div className={cx({
             "Home-filter": true,
             "is-fixed": false,
           })}>
             <Filter
-              data={this.state.categories}
-              filterOn={this.state.categoryOn}
-              toggleCategoryHandler={this.toggleCategory}
-              clearCategoryHandler={this.clearCategory}
+              data={this.state.venues}
+              filterOn={this.state.venueOn}
+              toggleCategoryHandler={this.toggleVenue}
+              clearCategoryHandler={this.clearVenue}
             />
           </div>
           <div className={cx({
@@ -207,10 +206,10 @@ export default class Schedule extends Component {
                 'is-show': this.state.mobileFilterOn,
               })}>
                 <Filter ref="filter"
-                        data={this.state.categories}
-                        filterOn={this.state.categoryOn}
-                        toggleCategoryHandler={this.toggleCategory}
-                        clearCategoryHandler={this.clearCategory}
+                        data={this.state.venues}
+                        filterOn={this.state.venueOn}
+                        toggleCategoryHandler={this.toggleVenue}
+                        clearCategoryHandler={this.clearVenue}
                         togglePanelHander={this.toggleMobileFilter}/>
               </div>
               <div
@@ -250,7 +249,7 @@ export default class Schedule extends Component {
               sessionHandler={this.resetSession}
               data={this.state.currentSession()}
               time={this.state.currentSessionTime}
-              categories={categories}
+              categories={venues}
             />
           </div>
 

--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -7,7 +7,29 @@ import styles from "./styles.css";
 import classnames from "classnames/bind";
 const cx = classnames.bind(styles);
 
-const noop = () => {}
+const venues = [
+  {
+    "id": "r1",
+    "title": "R1",
+    "color": "#F4AF3D"
+  },
+  {
+    "id": "r0",
+    "title": "R0",
+    "color": "#CE0D41"
+  },
+  {
+    "id": "r2",
+    "title": "R2",
+    "color": "#1BADBE"
+  }
+];
+
+const venueObj = venues.reduce((aggObj, venue, idx) => {
+  aggObj[venue.title] = venue
+  aggObj.index = idx
+  return aggObj
+}, {})
 
 function mapTimeSlotToItems(day, value, i) {
   let id = `day${day}-all-${i}`;
@@ -26,7 +48,7 @@ function mapTimeSlotToItems(day, value, i) {
       <div
         className={cx({ "Schedule-item" : true, })}
         key={i}
-        style={{ color: '#FFF', backgroundColor: value.color}}
+        style={{ color: '#FFF', backgroundColor: venueObj[value.venue].color}}
       >
         <div className="Schedule-time">
           {value.title}／{venue}
@@ -71,24 +93,6 @@ function mapTimeSlotToItems(day, value, i) {
     );
   }
 }
-
-const venues = [
-  {
-    "id": "r0",
-    "title": "R0",
-    "color": "#CE0D41"
-  },
-  {
-    "id": "r1",
-    "title": "R1",
-    "color": "#FCDE86"
-  },
-  {
-    "id": "r2",
-    "title": "R2",
-    "color": "#1BADBE"
-  }
-];
 
 export default class Schedule extends Component {
   constructor(props) {

--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -163,6 +163,7 @@ export default class Schedule extends Component {
             "is-fixed": false,
           })}>
             <Filter
+              title='venues'
               data={this.state.venues}
               filterOn={this.state.venueOn}
               toggleCategoryHandler={this.toggleVenue}
@@ -206,11 +207,12 @@ export default class Schedule extends Component {
                 'is-show': this.state.mobileFilterOn,
               })}>
                 <Filter ref="filter"
+                        title='venues'
                         data={this.state.venues}
                         filterOn={this.state.venueOn}
                         toggleCategoryHandler={this.toggleVenue}
                         clearCategoryHandler={this.clearVenue}
-                        togglePanelHander={this.toggleMobileFilter}/>
+                        togglePanelHandler={this.toggleMobileFilter}/>
               </div>
               <div
                 className={cx({

--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -84,6 +84,16 @@ function mapTimeSlotToItems(day, value, i) {
                 <div className="Schedule-main">
                   {value.event.title}
                   <div className="Schedule-presenter">{value.event.speaker}</div>
+                  {
+                    venue ? (
+                      <div className="Schedule-categoryIcon" style={{
+                             "background" : venueObj[venue].color
+                           }}
+                           title={`Toggle venue "${venue}"`}
+                           onClick={this.toggleVenue.bind(this, venueObj[venue].index)}
+                           ></div>
+                    ) : null
+                  }
                 </div>
               </a>
             }

--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -264,4 +264,4 @@ export default class Schedule extends Component {
   }
 }
 
-export {default as ScheduleParallel} from './time'
+export {default as ScheduleParallel} from './parallel'

--- a/app/javascripts/components/Schedule/parallel.jsx
+++ b/app/javascripts/components/Schedule/parallel.jsx
@@ -204,7 +204,8 @@ export default class ScheduleParallel extends Component {
             "Home-filter": true,
             "is-fixed": false,
           })} style={filterStyle}>
-            <Filter data={categories}
+            <Filter title="categories"
+                    data={categories}
                     filterOn={filterOn}
                     toggleCategoryHandler={this.toggleCategory}
                     clearCategoryHandler={this.clearCategory}/>
@@ -247,11 +248,12 @@ export default class ScheduleParallel extends Component {
                 'is-show': showPanel,
               })}>
                 <Filter ref="filter"
+                        title="categories"
                         data={categories}
                         filterOn={filterOn}
                         toggleCategoryHandler={this.toggleCategory}
                         clearCategoryHandler={this.clearCategory}
-                        togglePanelHander={this.togglePanel}/>
+                        togglePanelHandler={this.togglePanel}/>
               </div>
               <div ref="day1" id="day1">
                 <div className="Schedule-day">5/14 (Sat.)</div>

--- a/app/javascripts/components/Schedule/parallel.jsx
+++ b/app/javascripts/components/Schedule/parallel.jsx
@@ -138,19 +138,19 @@ export default class ScheduleParallel extends Component {
       }else{ //multile events
         let filteredEvents = value.events.filter(v => shouldPassFilter(v.category));
         if(filteredEvents.length === 0) return null;
- 
+
         content = (
           <div className="Schedule-events">
             {
               filteredEvents.map((v,k)=>{
                 var language = (v.EN) ? <div className="Schedule-en">EN</div> : "";
- 
+
                 var venue = (v.venue) ? (
                         <div className="Schedule-meta">
                           <div className="Schedule-venue">{v.venue}</div>
                         </div>) : "";
                 var id = `day${day}-${v.venue.toLowerCase()}-${i}`;
- 
+
                 return(
                   <a className={classNames({
                        "Schedule-event" : true
@@ -179,7 +179,7 @@ export default class ScheduleParallel extends Component {
           </div>
         );
       }
- 
+
 
       let [timeStart, timeEnd] = value.time.split('-')
       return (
@@ -198,6 +198,7 @@ export default class ScheduleParallel extends Component {
 
     return (
       <div className={styles.root}>
+        <div style={{ color: '#FFF', backgroundColor: '#000', padding: '20px', textAlign: 'center'}}>{schedules[getLocale()].interpretation}</div>
         <div className={styles.container}>
           <div className={classNames({
             "Home-filter": true,

--- a/app/javascripts/components/Schedule/session.jsx
+++ b/app/javascripts/components/Schedule/session.jsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import "./session.css";
 import speakers from '../SpeakerList/speakers.json';
 import schedules from './schedules.json';
+import categories from './categories.json';
 import { getLocale, getString } from "javascripts/locale";
 import avatarURL from "javascripts/helpers/avatar";
 import styles from "./styles.css";
@@ -15,8 +16,8 @@ export default React.createClass({
   displayName: "Session",
 
   render() {
-    var {sessionHandler, data, categories, time} = this.props;
-    var category = categories.find(cat => cat.id === data.category);
+    var {sessionHandler, data, time} = this.props;
+    var category = categories[getLocale()].find(cat => cat.id === data.category);
     var venue = (data.venue) ? <div className="Session-venue">{data.venue}</div> : "";
     var language = (data.EN) ? <div className="Session-en">EN</div> : "";
     const [locale] = getLocale().split('-');

--- a/app/javascripts/components/Schedule/styles.css
+++ b/app/javascripts/components/Schedule/styles.css
@@ -303,6 +303,12 @@ $mobile-item-leftstop: 96px;
 .Schedule-keynote {
   background: #eff;
 }
+
+.Schedule-item:not(.Schedule-keynote) + .Schedule-keynote {
+  /* topic-view only: end of parallel session, make border more distinct */
+  margin-top: 2px;
+  border-top: 1px solid rgb(220,220,220);
+}
 .Schedule-item {
   display: flex;
   font-size: 16px;


### PR DESCRIPTION
This pull request is targeting the discussions here:
https://logbot.g0v.tw/channel/g0v.tw/2016-04-08#36

<img width="799" alt="2016-04-10 3 23 42" src="https://cloud.githubusercontent.com/assets/108608/14408664/b31b46c4-ff30-11e5-824e-1507e70fc669.png">
- [Design change] Use **venue color coding** instead of **category color coding** in "Topic View" of schedule page. It is confusing to have 2 color coding schemes (venue filter colors & category colors) in the same page, thus I decide to remove category colors in "Topic View".
- Fixes a bug in <Session> that categories does not show up.
- File naming & property naming fixes.
