### PR TITLE
Sticky filter & control in schedule page

### DIFF
--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -5,6 +5,7 @@ import Filter from "./filter";
 import Session from './session';
 import styles from "./styles.css";
 import classnames from "classnames/bind";
+import { StickyContainer, Sticky } from 'react-sticky';
 const cx = classnames.bind(styles);
 
 const venues = [
@@ -171,103 +172,108 @@ export default class Schedule extends Component {
     return (
       <div className={styles.root}>
         <div style={{ color: '#FFF', backgroundColor: '#000', padding: '20px', textAlign: 'center'}}>{schedules[getLocale()].interpretation}</div>
-        <div className={styles.container}>
-          <div className={cx({
-            "Home-filter": true,
-          })}>
-            <Filter
-              title='venues'
-              data={this.state.venues}
-              filterOn={this.state.venueOn}
-              toggleCategoryHandler={this.toggleVenue}
-              clearCategoryHandler={this.clearVenue}
-            />
-          </div>
-          <div className={cx({
-            "Home-schedule": true,
-            "with-session" : this.state.showSession,
-          })}>
-            <div className={`Schedule`}>
-              <div className={cx({
-                  "Schedule-title" : true,
-                  "with-session" : this.state.showSession,
-                  "without-session" : !this.state.showSession
-                })}>
-                <div className="Schedule-dayButtonLeftstop">
+        <StickyContainer>
+          <div className={styles.container}>
+            <div className={cx({
+              "Home-filter": true,
+            })}>
+              <Sticky topOffset={-60} stickyStyle={{marginTop: 60}}>
+                <Filter
+                  title='venues'
+                  data={this.state.venues}
+                  filterOn={this.state.venueOn}
+                  toggleCategoryHandler={this.toggleVenue}
+                  clearCategoryHandler={this.clearVenue}
+                />
+              </Sticky>
+            </div>
+            <div className={cx({
+              "Home-schedule": true,
+              "with-session" : this.state.showSession,
+            })}>
+              <div className={`Schedule`}>
+                <Sticky topOffset={-60} stickyStyle={{marginTop: 60}}>
                   <div className={cx({
-                         "Schedule-dayButton" : true,
-                         "is-active" : this.state.currentSection === "day1"
-                       })}
-                       onClick={this.setSection.bind(this, 'day1')}>Day 1</div>
+                      "Schedule-title" : true,
+                      "with-session" : this.state.showSession,
+                      "without-session" : !this.state.showSession
+                    })}>
+                    <div className="Schedule-dayButtonLeftstop">
+                      <div className={cx({
+                             "Schedule-dayButton" : true,
+                             "is-active" : this.state.currentSection === "day1"
+                           })}
+                           onClick={this.setSection.bind(this, 'day1')}>Day 1</div>
+                    </div>
+                    <div className={cx({
+                           "Schedule-dayButton" : true,
+                           "is-active" : this.state.currentSection === "day2"
+                         })}
+                         onClick={this.setSection.bind(this, 'day2')}>Day 2</div>
+                    <div className="Schedule-switchBtn" onClick={this.props.onSwitch}>View Parallel</div>
+                    <div className={cx({
+                           'Schedule-filterBtn': true,
+                           'is-show': this.state.mobileFilterOn,
+                         })}
+                         onClick={this.toggleMobileFilter}>Filter
+                      <div className={cx({'Schedule-bar1': true, 'is-active': this.state.mobileFilterOn})}></div>
+                      <div className={cx({'Schedule-bar2': true, 'is-active': this.state.mobileFilterOn})}></div>
+                    </div>
+                  </div>
+                  <div className={cx({
+                    'Schedule-filterPanel': true,
+                    'is-show': this.state.mobileFilterOn,
+                  })}>
+                    <Filter ref="filter"
+                            title='venues'
+                            data={this.state.venues}
+                            filterOn={this.state.venueOn}
+                            toggleCategoryHandler={this.toggleVenue}
+                            clearCategoryHandler={this.clearVenue}
+                            togglePanelHandler={this.toggleMobileFilter}/>
+                  </div>
+                </Sticky>
+                <div
+                  className={cx({
+                    "Home-section": true,
+                    "is-hidden": this.state.currentSection !== ''&& this.state.currentSection !== 'day1'
+                  })}
+                  ref={(c) => this.day1 = c}
+                  id="day1"
+                >
+                  <div className="Schedule-day">5/14 (Sat.)</div>
+                  <section>
+                    {schedules[getLocale()]["day1"].map(mapTimeSlotToItems.bind(this, 1))}
+                  </section>
                 </div>
-                <div className={cx({
-                       "Schedule-dayButton" : true,
-                       "is-active" : this.state.currentSection === "day2"
-                     })}
-                     onClick={this.setSection.bind(this, 'day2')}>Day 2</div>
-                <div className="Schedule-switchBtn" onClick={this.props.onSwitch}>View Parallel</div>
-                <div className={cx({
-                       'Schedule-filterBtn': true,
-                       'is-show': this.state.mobileFilterOn,
-                     })}
-                     onClick={this.toggleMobileFilter}>Filter
-                  <div className={cx({'Schedule-bar1': true, 'is-active': this.state.mobileFilterOn})}></div>
-                  <div className={cx({'Schedule-bar2': true, 'is-active': this.state.mobileFilterOn})}></div>
+                <div
+                  className={cx({
+                    "Home-section": true,
+                    "is-hidden": this.state.currentSection !== '' && this.state.currentSection !== 'day2'
+                  })}
+                  ref={(c) => this.day2 = c}
+                  id="day2"
+                >
+                  <div className="Schedule-day">5/15 (Sun.)</div>
+                  <section>
+                    {schedules[getLocale()]["day2"].map(mapTimeSlotToItems.bind(this, 2))}
+                  </section>
                 </div>
-              </div>
-              <div className={cx({
-                'Schedule-filterPanel': true,
-                'is-show': this.state.mobileFilterOn,
-              })}>
-                <Filter ref="filter"
-                        title='venues'
-                        data={this.state.venues}
-                        filterOn={this.state.venueOn}
-                        toggleCategoryHandler={this.toggleVenue}
-                        clearCategoryHandler={this.clearVenue}
-                        togglePanelHandler={this.toggleMobileFilter}/>
-              </div>
-              <div
-                className={cx({
-                  "Home-section": true,
-                  "is-hidden": this.state.currentSection !== ''&& this.state.currentSection !== 'day1'
-                })}
-                ref={(c) => this.day1 = c}
-                id="day1"
-              >
-                <div className="Schedule-day">5/14 (Sat.)</div>
-                <section>
-                  {schedules[getLocale()]["day1"].map(mapTimeSlotToItems.bind(this, 1))}
-                </section>
-              </div>
-              <div
-                className={cx({
-                  "Home-section": true,
-                  "is-hidden": this.state.currentSection !== '' && this.state.currentSection !== 'day2'
-                })}
-                ref={(c) => this.day2 = c}
-                id="day2"
-              >
-                <div className="Schedule-day">5/15 (Sun.)</div>
-                <section>
-                  {schedules[getLocale()]["day2"].map(mapTimeSlotToItems.bind(this, 2))}
-                </section>
               </div>
             </div>
+            <div className={cx({
+                "Home-session" : true,
+                "is-show": this.state.showSession,
+              })}>
+              <Session
+                sessionHandler={this.resetSession}
+                data={this.state.currentSession()}
+                time={this.state.currentSessionTime}
+                categories={venues}
+              />
+            </div>
           </div>
-          <div className={cx({
-              "Home-session" : true,
-              "is-show": this.state.showSession,
-            })}>
-            <Session
-              sessionHandler={this.resetSession}
-              data={this.state.currentSession()}
-              time={this.state.currentSessionTime}
-              categories={venues}
-            />
-          </div>
-
-        </div>
+        </StickyContainer>
         <div className={cx({
           backdrop: true,
           isShown: this.state.showSession,

--- a/app/javascripts/components/Schedule/index.jsx
+++ b/app/javascripts/components/Schedule/index.jsx
@@ -174,7 +174,6 @@ export default class Schedule extends Component {
         <div className={styles.container}>
           <div className={cx({
             "Home-filter": true,
-            "is-fixed": false,
           })}>
             <Filter
               title='venues'
@@ -188,7 +187,7 @@ export default class Schedule extends Component {
             "Home-schedule": true,
             "with-session" : this.state.showSession,
           })}>
-            <div className={`Schedule`}>{/* todo: is-fixed */}
+            <div className={`Schedule`}>
               <div className={cx({
                   "Schedule-title" : true,
                   "with-session" : this.state.showSession,
@@ -259,7 +258,6 @@ export default class Schedule extends Component {
           <div className={cx({
               "Home-session" : true,
               "is-show": this.state.showSession,
-              "is-fixed": true,
             })}>
             <Session
               sessionHandler={this.resetSession}

--- a/app/javascripts/components/Schedule/parallel.jsx
+++ b/app/javascripts/components/Schedule/parallel.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { Link } from "react-router";
+import { StickyContainer, Sticky } from 'react-sticky';
 import { getLocale } from "javascripts/locale";
 import schedules from './schedules.json';
 import categoriesData from './categories.json';
@@ -199,85 +200,91 @@ export default class ScheduleParallel extends Component {
     return (
       <div className={styles.root}>
         <div style={{ color: '#FFF', backgroundColor: '#000', padding: '20px', textAlign: 'center'}}>{schedules[getLocale()].interpretation}</div>
-        <div className={styles.container}>
-          <div className={classNames({
-            "Home-filter": true,
-          })} style={filterStyle}>
-            <Filter title="categories"
-                    data={categories}
-                    filterOn={filterOn}
-                    toggleCategoryHandler={this.toggleCategory}
-                    clearCategoryHandler={this.clearCategory}/>
-          </div>
-          <div className={classNames({
-            "Home-schedule": true,
-            "with-session" : showSession,
-          })}>
-            <div className={`Schedule`}>
-              <div className={classNames({
-                  "Schedule-title" : true,
-                  "with-session" : showSession,
-                  "without-session" : !showSession
-                })}>
-                <div className="Schedule-dayButtonLeftstop">
-                  <div className={classNames({
-                         "Schedule-dayButton" : true,
-                         /* "is-active" : currentSection === "day1" */
-                       })}
-                       onClick={this.goToElement.bind(this,"day1")}>Day 1</div>
-                </div>
-                <div className={classNames({
-                       "Schedule-dayButton" : true,
-                       /* "is-active" : currentSection === "day2" */
-                     })}
-                     onClick={this.goToElement.bind(this,"day2")}>Day 2</div>
-                <div className="Schedule-switchBtn" onClick={this.props.onSwitch}>View Topics</div>
-                <div className={classNames({
-                       'Schedule-filterBtn': true,
-                       'is-show': showPanel,
-                     })}
-                     onClick={this.togglePanel}>Filter
-                  <div className={classNames({'Schedule-bar1': true, 'is-active': showPanel})}></div>
-                  <div className={classNames({'Schedule-bar2': true, 'is-active': showPanel})}></div>
-                </div>
-              </div>
-              <div className={classNames({
-                'Schedule-filterPanel': true,
-                'is-show': showPanel,
-              })}>
-                <Filter ref="filter"
-                        title="categories"
+        <StickyContainer>
+          <div className={styles.container}>
+            <div className={classNames({
+              "Home-filter": true,
+            })} style={filterStyle}>
+              <Sticky topOffset={-60} stickyStyle={{marginTop: 60}}>
+                <Filter title="categories"
                         data={categories}
                         filterOn={filterOn}
                         toggleCategoryHandler={this.toggleCategory}
-                        clearCategoryHandler={this.clearCategory}
-                        togglePanelHandler={this.togglePanel}/>
-              </div>
-              <div ref="day1" id="day1">
-                <div className="Schedule-day">5/14 (Sat.)</div>
-                <section>
-                  {schedules[getLocale()]["day1"].map(mapTimeSlotToItems.bind(this, 1))}
-                </section>
-              </div>
-              <div ref="day2" id="day2">
-                <div className="Schedule-day">5/15 (Sun.)</div>
-                <section>
-                  {schedules[getLocale()]["day2"].map(mapTimeSlotToItems.bind(this, 2))}
-                </section>
+                        clearCategoryHandler={this.clearCategory}/>
+              </Sticky>
+            </div>
+            <div className={classNames({
+              "Home-schedule": true,
+              "with-session" : showSession,
+            })}>
+              <div className={`Schedule`}>
+                <Sticky topOffset={-60} stickyStyle={{marginTop: 60}}>
+                  <div className={classNames({
+                      "Schedule-title" : true,
+                      "with-session" : showSession,
+                      "without-session" : !showSession
+                    })}>
+                    <div className="Schedule-dayButtonLeftstop">
+                      <div className={classNames({
+                             "Schedule-dayButton" : true,
+                             /* "is-active" : currentSection === "day1" */
+                           })}
+                           onClick={this.goToElement.bind(this,"day1")}>Day 1</div>
+                    </div>
+                    <div className={classNames({
+                           "Schedule-dayButton" : true,
+                           /* "is-active" : currentSection === "day2" */
+                         })}
+                         onClick={this.goToElement.bind(this,"day2")}>Day 2</div>
+                    <div className="Schedule-switchBtn" onClick={this.props.onSwitch}>View Topics</div>
+                    <div className={classNames({
+                           'Schedule-filterBtn': true,
+                           'is-show': showPanel,
+                         })}
+                         onClick={this.togglePanel}>Filter
+                      <div className={classNames({'Schedule-bar1': true, 'is-active': showPanel})}></div>
+                      <div className={classNames({'Schedule-bar2': true, 'is-active': showPanel})}></div>
+                    </div>
+                  </div>
+                  <div className={classNames({
+                    'Schedule-filterPanel': true,
+                    'is-show': showPanel,
+                  })}>
+                    <Filter ref="filter"
+                            title="categories"
+                            data={categories}
+                            filterOn={filterOn}
+                            toggleCategoryHandler={this.toggleCategory}
+                            clearCategoryHandler={this.clearCategory}
+                            togglePanelHandler={this.togglePanel}/>
+                  </div>
+                </Sticky>
+                <div ref="day1" id="day1">
+                  <div className="Schedule-day">5/14 (Sat.)</div>
+                  <section>
+                    {schedules[getLocale()]["day1"].map(mapTimeSlotToItems.bind(this, 1))}
+                  </section>
+                </div>
+                <div ref="day2" id="day2">
+                  <div className="Schedule-day">5/15 (Sun.)</div>
+                  <section>
+                    {schedules[getLocale()]["day2"].map(mapTimeSlotToItems.bind(this, 2))}
+                  </section>
+                </div>
               </div>
             </div>
-          </div>
-          <div className={classNames({
-              "Home-session" : true,
-              "is-show": showSession,
-            })}
-            style={sessionStyle}>
-            <Session sessionHandler={this.resetSession}
-                     data={currentSession()} time={this.state.currentSessionTime}
-                     categories={this.state.categories}/>
-          </div>
+            <div className={classNames({
+                "Home-session" : true,
+                "is-show": showSession,
+              })}
+              style={sessionStyle}>
+              <Session sessionHandler={this.resetSession}
+                       data={currentSession()} time={this.state.currentSessionTime}
+                       categories={this.state.categories}/>
+            </div>
 
-        </div>
+          </div>
+        </StickyContainer>
         <div className={cx({
           backdrop: true,
           isShown: showSession,

--- a/app/javascripts/components/Schedule/parallel.jsx
+++ b/app/javascripts/components/Schedule/parallel.jsx
@@ -202,7 +202,6 @@ export default class ScheduleParallel extends Component {
         <div className={styles.container}>
           <div className={classNames({
             "Home-filter": true,
-            "is-fixed": false,
           })} style={filterStyle}>
             <Filter title="categories"
                     data={categories}
@@ -214,12 +213,11 @@ export default class ScheduleParallel extends Component {
             "Home-schedule": true,
             "with-session" : showSession,
           })}>
-            <div className={`Schedule`}>{/* todo: is-fixed */}
+            <div className={`Schedule`}>
               <div className={classNames({
                   "Schedule-title" : true,
                   "with-session" : showSession,
                   "without-session" : !showSession
-                  /*"is-fixed" : inScheduleArea==="within" || (inScheduleArea==="passed" && showPanel),*/
                 })}>
                 <div className="Schedule-dayButtonLeftstop">
                   <div className={classNames({
@@ -272,7 +270,6 @@ export default class ScheduleParallel extends Component {
           <div className={classNames({
               "Home-session" : true,
               "is-show": showSession,
-              "is-fixed": true,
             })}
             style={sessionStyle}>
             <Session sessionHandler={this.resetSession}

--- a/app/javascripts/components/Schedule/styles.css
+++ b/app/javascripts/components/Schedule/styles.css
@@ -76,6 +76,7 @@ body.mobileScrollLock {
 
 @media screen and (min-width: $breakpoint){
   $left-filter-width: 240px;
+  $left-filter-shirnked-width: 36px;
 
   .Home-filter {
     width: $left-filter-width;
@@ -87,13 +88,22 @@ body.mobileScrollLock {
   .Home-schedule {
     margin-left: $left-filter-width;
     border-left: 1px solid gray;
-    position: relative; /* make z-index work */
+    position: relative; /* make z-index work & moves when session is showed up */
     z-index: 10;
-    transition: transform .2s cubic-bezier(.4,0,.2,1);
-    transform: translate3d(0, 0, 0);
+    transition: left .2s cubic-bezier(.4,0,.2,1); /* Cannot use transform because we've got a sticky schedule title */
+    left: 0;
   }
   .Home-schedule.with-session {
-    transform: translate3d(calc(36px - $left-filter-width), 0, 0);
+    left: calc($left-filter-shirnked-width - $left-filter-width);
+  }
+  .Home-schedule .sticky {
+    /* Overriding react-sticky to make sticky items move with Home-Schedule */
+    left: calc((100% - $container-width) / 2 + $left-filter-width + 1px) !important;
+    transform: translate3d(0,0,0);
+    transition: transform .2s cubic-bezier(.4,0,.2,1);
+  }
+  .Home-schedule.with-session .sticky {
+    transform: translate3d(calc($left-filter-shirnked-width - $left-filter-width),0,0);
   }
   .Home-session {
     position: fixed;
@@ -118,27 +128,23 @@ body.mobileScrollLock {
   background: white;
   z-index: 10;
 }
+
+.Schedule .sticky {
+  z-index: 20;
+}
+
 .Schedule-title {
-  background: white;
+  background: rgba(255, 255, 255, .9);
   border-bottom: 1px solid gray;
   width: 100%;
   z-index: 20;
   display: flex;
-}
-@media screen and (min-width: 776px) and (max-width: 1236px){
-  .Schedule-title {
-    background: white;
-    border-bottom: 1px solid gray;
-    width: 100%;
-    z-index: 20;
-  }
 }
 @media screen and (min-width: $breakpoint){
   .Schedule-title {
     background: white;
     border-bottom: 1px solid gray;
     width: 100%;
-    z-index: 20;
   }
 }
 
@@ -197,10 +203,12 @@ body.mobileScrollLock {
   max-height: 0px;
   overflow: hidden;
   will-change: max-height;
+  background: rgba(255, 255, 255, .9);
   transition: all .2s cubic-bezier(0, 1, 0.5, 1);
 }
 .Schedule-filterPanel.is-show {
   max-height: calc(100vh - 80px);
+  border-bottom: 1px solid gray;
 }
 
 @media screen and (min-width: $breakpoint){

--- a/app/javascripts/components/Schedule/styles.css
+++ b/app/javascripts/components/Schedule/styles.css
@@ -66,7 +66,7 @@ body.mobileScrollLock {
   z-index: 200;
   transform: translate3d(100%, 0, 0);
 }
-.Home-session.is-show, .Home-session.is-show.is-fixed {
+.Home-session.is-show {
   transform: translate3d(0, 0, 0);
 }
 
@@ -84,41 +84,31 @@ body.mobileScrollLock {
     left: 0;
     display: block;
   }
-  .Home-filter.is-fixed {
-    position: fixed;
-  }
-  .Home-filter.is-passed {
-    position: absolute;
-    /* top dynamically decided*/
-  }
   .Home-schedule {
     margin-left: $left-filter-width;
     border-left: 1px solid gray;
     position: relative; /* make z-index work */
     z-index: 10;
     transition: transform .2s cubic-bezier(.4,0,.2,1);
-    transform: translate3d(0,0,0);
+    transform: translate3d(0, 0, 0);
   }
   .Home-schedule.with-session {
-    transform: translate3d(calc(36px - $left-filter-width),0,0);
+    transform: translate3d(calc(36px - $left-filter-width), 0, 0);
   }
   .Home-session {
-    position: absolute;
+    position: fixed;
     opacity: 0;
     left: 50%;
     width: 50%;
-    height: 100vh;
+    height: calc(100vh - $appbar-height);
     overflow-y: auto;
     transition-property: opacity, transform;
+
+    margin-top: $appbar-height;
+    box-shadow: -3px 4px 4px rgba(0,0,0,.2);
   }
   .Home-session.is-show {
     opacity: 1;
-  }
-  .Home-session.is-fixed {
-    position: fixed;
-    height: calc(100vh - $appbar-height);
-    margin-top: $appbar-height;
-    box-shadow: -3px 4px 4px rgba(0,0,0,.2);
   }
 }
 
@@ -128,9 +118,6 @@ body.mobileScrollLock {
   background: white;
   z-index: 10;
 }
-.Schedule.is-fixed {
-  padding-top: 56px;
-}
 .Schedule-title {
   background: white;
   border-bottom: 1px solid gray;
@@ -138,29 +125,13 @@ body.mobileScrollLock {
   z-index: 20;
   display: flex;
 }
-.Schedule-title.is-fixed {
-  position: fixed;
-  top: 0;
-
-  transition: all .2s cubic-bezier(.4,0,.2,1);
-}
 @media screen and (min-width: 776px) and (max-width: 1236px){
   .Schedule-title {
     background: white;
     border-bottom: 1px solid gray;
     width: 100%;
     z-index: 20;
-
   }
-  .Schedule-title.is-fixed {
-    position: fixed;
-    top: 0;
-    max-width: calc(50% - 2px);
-
-    -webkit-transition: all .2s cubic-bezier(.4,0,.2,1);
-    transition: all .2s cubic-bezier(.4,0,.2,1);
-  }
-
 }
 @media screen and (min-width: $breakpoint){
   .Schedule-title {
@@ -168,28 +139,6 @@ body.mobileScrollLock {
     border-bottom: 1px solid gray;
     width: 100%;
     z-index: 20;
-  }
-  .Schedule-title.is-fixed.without-session {
-    left: 361px;
-
-    position: fixed;
-    top: 0;
-    max-width: 548px;
-
-    -webkit-transition: all .2s cubic-bezier(.4,0,.2,1);
-    transition: all .2s cubic-bezier(.4,0,.2,1);
-    will-change: left;
-  }
-  .Schedule-title.is-fixed.with-session {
-    left: 161px;
-
-    position: fixed;
-    top: 0;
-    max-width: 548px;
-
-    -webkit-transition: all .2s cubic-bezier(.4,0,.2,1);
-    transition: all .2s cubic-bezier(.4,0,.2,1);
-    will-change: left;
   }
 }
 
@@ -253,14 +202,6 @@ body.mobileScrollLock {
 .Schedule-filterPanel.is-show {
   max-height: calc(100vh - 80px);
 }
-.Schedule-filterPanel.is-show.is-fixed {
-  position: fixed;
-  top: 57px;
-  z-index: 200;
-  width: 100%;
-  background: white;
-  box-shadow: 0px 2px 2px 0 rgba(0,0,0,.22);
-}
 
 @media screen and (min-width: $breakpoint){
   /* No filterButton and filterPanel on desktop */
@@ -268,7 +209,7 @@ body.mobileScrollLock {
     display: none;
   }
 
-  .Schedule-filterPanel.is-show.is-show { /* specificity override .is-show.is-fixed */
+  .Schedule-filterPanel.is-show.is-show {
      display: none;
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^0.14.7",
     "react-ga": "^1.2.0",
     "react-router": "^2.0.0",
+    "react-sticky": "^4.0.2",
     "sitemap": "^1.5.0",
     "style-loader": "^0.13.0",
     "superstatic": "^4.0.2",


### PR DESCRIPTION
![schedule-fix](https://cloud.githubusercontent.com/assets/108608/14409554/0c39adb4-ff49-11e5-91e0-1580b5200906.gif)

Fixes #180 (but not the "move day toggle to the left column" part though.)
